### PR TITLE
Implements tracking of resume link clicking

### DIFF
--- a/src/routes/PositionDetails/components/PositionCandidates/styles.module.scss
+++ b/src/routes/PositionDetails/components/PositionCandidates/styles.module.scss
@@ -81,10 +81,22 @@
   display: inline-flex;
   align-items: center;
   margin-top: 5px;
+  border: none;
+  padding: 0;
+  width: auto;
+  height: auto;
+  color: #0d61bf;
+  background: transparent;
+  outline: none !important;
+  box-shadow: none !important;
 
   > svg {
     margin-right: 10px;
   }
+}
+
+.busy {
+  cursor: wait;
 }
 
 @media (max-width: 850px) {

--- a/src/services/requestInterceptor.js
+++ b/src/services/requestInterceptor.js
@@ -35,3 +35,11 @@ axiosInstance.interceptors.response.use(
     return Promise.reject(error);
   }
 );
+
+export const fetchCustom = async (url, init = {}) => {
+  let { tokenV3 } = await getAuthUserTokens();
+  let headers = init.headers || {};
+  headers.Authorization = `Bearer ${tokenV3}`;
+  init.headers = headers;
+  return fetch(url, init);
+};

--- a/src/services/teams.js
+++ b/src/services/teams.js
@@ -1,7 +1,11 @@
 /**
  * Topcoder TaaS Service
  */
-import { axiosInstance as axios } from "./requestInterceptor";
+import {
+  axiosInstance as axios,
+  fetchCustom as fetch,
+} from "./requestInterceptor";
+
 import config from "../../config";
 
 /**
@@ -91,6 +95,25 @@ export const patchCandidateInterview = (candidateId, interviewData) => {
     `${config.API.V5}/jobCandidates/${candidateId}/requestInterview`,
     interviewData
   );
+};
+
+/**
+ * Sends request to candidate's resume URL while trying to avoid downloading
+ * the resume itself.
+ *
+ * @param {string} candidateId interview candidate id
+ * @returns {Promise}
+ */
+export const touchCandidateResume = async (candidateId) => {
+  try {
+    // The result of redirect to different origin will not contain any useful
+    // data. See https://fetch.spec.whatwg.org/#atomic-http-redirect-handling
+    await fetch(`${config.API.V5}/jobCandidates/${candidateId}/resume`, {
+      redirect: "manual",
+    });
+  } catch (error) {
+    console.error(error);
+  }
 };
 
 /**


### PR DESCRIPTION
Implements #492.
Note that this code relies on the presence of valid candidate's resume URL in `candidate.resume` as there's no way to get any data from responses that are cross-origin redirects.